### PR TITLE
Fix deleting contacts during destroyBody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [next]
+ - Fix bug that throws error during World.destroyBody(), Body.setType() and Body.setActive() if body has some contacts
+
 ## 0.6.0
  - Refactor joints, fixtures and contacts not to be linked lists
  - Make force/impulses default to the center of a body

--- a/lib/src/dynamics/body.dart
+++ b/lib/src/dynamics/body.dart
@@ -581,7 +581,9 @@ class Body {
     _torque = 0.0;
 
     // Delete the attached contacts.
-    contacts.forEach(world._contactManager.destroy);
+    while (contacts.isNotEmpty) {
+      world._contactManager.destroy(contacts.first);
+    }
     contacts.clear();
 
     // Touch the proxies so that new contacts will be created (when appropriate)
@@ -688,7 +690,9 @@ class Body {
       }
 
       // Destroy the attached contacts.
-      contacts.forEach(world._contactManager.destroy);
+      while (contacts.isNotEmpty) {
+        world._contactManager.destroy(contacts.first);
+      }
       contacts.clear();
     }
   }

--- a/lib/src/dynamics/world.dart
+++ b/lib/src/dynamics/world.dart
@@ -161,7 +161,9 @@ class World {
     }
 
     // Delete the attached contacts.
-    body.contacts.forEach(_contactManager.destroy);
+    while (body.contacts.isNotEmpty) {
+      _contactManager.destroy(body.contacts.first);
+    }
     body.contacts.clear();
 
     for (Fixture f in body.fixtures) {


### PR DESCRIPTION
There was a fundamental bug with deleting elements from the list during iterating it.
Calling destroy() on contact manager calls 
```
c.bodyA.contacts.remove(c);
c.bodyB.contacts.remove(c);
```
which deletes the contact from body's contacts list.