### PR TITLE
Allow modification of velocityThreshold.

### DIFF
--- a/lib/src/settings.dart
+++ b/lib/src/settings.dart
@@ -42,7 +42,7 @@ const int maxTOIContacts = 32;
 
 /// A velocity threshold for elastic collisions. Any collision with a relative linear velocity
 /// below this threshold will be treated as inelastic.
-const double velocityThreshold = 1.0;
+double velocityThreshold = 1.0;
 
 /// The maximum linear position correction used when solving constraints. This helps to prevent
 /// overshoot.


### PR DESCRIPTION
This PR makes settings.velocityThreshold mutable.

This setting was mutable in box2d, see the CHANGELOG.md entry "Made velocityThreshold mutable (as per jbox2d and other box2d implementations)."

It became constant in this changeset: https://github.com/flame-engine/forge2d/commit/a89ee1fd8cd1a066e6f191dd7c28340b1087bbc1

Without allowing it to be mutated, some simulations develop the behaviour described here: https://gamedev.stackexchange.com/questions/98851/body-lost-a-velocity-component-when-hitting-a-wall