### PR TITLE
fix: Avoid ConcurrentModificationError when destroying joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [Next]
+ - Fix `ConcurrentModificationError` when destroying a body with joints
+
 ## 0.8.1
  - Export `settings.dart`
  - Make fields in `settings.dart` mutable

--- a/lib/src/dynamics/world.dart
+++ b/lib/src/dynamics/world.dart
@@ -141,7 +141,8 @@ class World {
     assert(!isLocked);
 
     // Delete the attached joints.
-    for (final joint in body.joints) {
+    while (body.joints.isNotEmpty) {
+      final joint = body.joints.first;
       destroyListener?.onDestroyJoint(joint);
       destroyJoint(joint);
     }


### PR DESCRIPTION
#34 