### PR TITLE
chore: Add test for joint destruction and publish 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [Next]
+## 0.8.2
  - Fix `ConcurrentModificationError` when destroying a body with joints
 
 ## 0.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: forge2d
-version: 0.8.1
+version: 0.8.2
 description: A 2D physics engine for Dart, also works with the Flame game engine in Flutter
 homepage: https://github.com/flame-engine/forge2d
 
@@ -8,3 +8,6 @@ environment:
 
 dependencies:
   vector_math: '>=2.1.0 <3.0.0'
+
+dev_dependencies:
+  test: ^1.20.1

--- a/test/joints_test.dart
+++ b/test/joints_test.dart
@@ -1,0 +1,34 @@
+import 'package:forge2d/forge2d.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Joints', () {
+    test('destruction of body with joint', () {
+      final world = World(Vector2(0.0, -10.0));
+      final bodyDef = BodyDef();
+      final body1 = world.createBody(bodyDef);
+      final body2 = world.createBody(bodyDef..position = Vector2.all(2));
+      final shape = CircleShape()
+        ..radius = 1.2
+        ..position.setValues(10, 10);
+
+      final fixtureDef = FixtureDef(shape)
+        ..density = 50.0
+        ..friction = .1
+        ..restitution = .9;
+
+      body1.createFixture(fixtureDef);
+      body2.createFixture(fixtureDef);
+
+      final revoluteJointDef = RevoluteJointDef()
+        ..initialize(body1, body2, body1.position);
+      world.createJoint(revoluteJointDef);
+
+      expect(body1.joints.length, 1);
+      expect(body2.joints.length, 1);
+      world.destroyBody(body1);
+      expect(body1.joints.length, 0);
+      expect(body2.joints.length, 0);
+    });
+  });
+}


### PR DESCRIPTION
# Description

Adds a test to check that joint destruction works properly when a body is destroyed.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org