### PR TITLE
feat: allowed specifying BodyDef properties via constructor

### DIFF
--- a/packages/forge2d/lib/src/dynamics/body_def.dart
+++ b/packages/forge2d/lib/src/dynamics/body_def.dart
@@ -3,56 +3,74 @@ import '../../forge2d.dart';
 /// A body definition holds all the data needed to construct a rigid body. You can safely re-use body
 /// definitions. Shapes are added to a body after construction.
 class BodyDef {
+  BodyDef({
+    this.type = BodyType.static,
+    this.userData,
+    Vector2? position,
+    this.angle = 0.0,
+    Vector2? linearVelocity,
+    this.angularVelocity = 0.0,
+    this.linearDamping = 0.0,
+    this.angularDamping = 0.0,
+    this.allowSleep = true,
+    this.isAwake = true,
+    this.fixedRotation = false,
+    this.bullet = false,
+    this.active = true,
+    this.gravityScale = 1.0,
+  })  : position = position ?? Vector2.zero(),
+        linearVelocity = linearVelocity ?? Vector2.zero();
+
   /// The body type: static, kinematic, or dynamic. Note: if a dynamic body would have zero mass, the
   /// mass is set to one.
-  BodyType type = BodyType.static;
+  BodyType type;
 
   /// Use this to store application specific body data.
   Object? userData;
 
   /// The world position of the body. Avoid creating bodies at the origin since this can lead to many
   /// overlapping shapes.
-  Vector2 position = Vector2.zero();
+  Vector2 position;
 
   /// The world angle of the body in radians.
-  double angle = 0.0;
+  double angle;
 
   /// The linear velocity of the body in world co-ordinates.
-  Vector2 linearVelocity = Vector2.zero();
+  Vector2 linearVelocity;
 
   /// The angular velocity of the body.
-  double angularVelocity = 0.0;
+  double angularVelocity;
 
   /// Linear damping is use to reduce the linear velocity. The damping parameter can be larger than
   /// 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
   /// large.
-  double linearDamping = 0.0;
+  double linearDamping;
 
   /// Angular damping is use to reduce the angular velocity. The damping parameter can be larger than
   /// 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
   /// large.
-  double angularDamping = 0.0;
+  double angularDamping;
 
   /// Set this flag to false if this body should never fall asleep. Note that this increases CPU
   /// usage.
-  bool allowSleep = true;
+  bool allowSleep;
 
   /// Is this body initially sleeping?
-  bool isAwake = true;
+  bool isAwake;
 
   /// Should this body be prevented from rotating? Useful for characters.
-  bool fixedRotation = false;
+  bool fixedRotation;
 
   /// Is this a fast moving body that should be prevented from tunneling through other moving bodies?
   /// Note that all bodies are prevented from tunneling through kinematic and static bodies. This
   /// setting is only considered on dynamic bodies.
   ///
   /// @warning You should use this flag sparingly since it increases processing time.
-  bool bullet = false;
+  bool bullet;
 
   /// Does this body start out active?
-  bool active = true;
+  bool active;
 
   /// Experimental: scales the inertia tensor.
-  double gravityScale = 1.0;
+  double gravityScale;
 }

--- a/packages/forge2d/lib/src/dynamics/body_def.dart
+++ b/packages/forge2d/lib/src/dynamics/body_def.dart
@@ -1,7 +1,11 @@
 import '../../forge2d.dart';
 
-/// A body definition holds all the data needed to construct a rigid body. You can safely re-use body
-/// definitions. Shapes are added to a body after construction.
+/// Holds all the data needed to construct a [Body].
+///
+/// You can safely re-use body definitions.
+///
+/// [Shape]s are added through [Fixture]s to a [Body] after construction via
+/// [Body.createFixture].
 class BodyDef {
   BodyDef({
     this.type = BodyType.static,
@@ -21,15 +25,18 @@ class BodyDef {
   })  : position = position ?? Vector2.zero(),
         linearVelocity = linearVelocity ?? Vector2.zero();
 
-  /// The body type: static, kinematic, or dynamic. Note: if a dynamic body would have zero mass, the
-  /// mass is set to one.
+  /// The body type: static, kinematic, or dynamic.
+  ///
+  /// Note: A [BodyType.dynamic] body with zero mass, will have a mass of one.
   BodyType type;
 
   /// Use this to store application specific body data.
   Object? userData;
 
-  /// The world position of the body. Avoid creating bodies at the origin since this can lead to many
-  /// overlapping shapes.
+  /// The world position of the body.
+  ///
+  /// Avoid creating bodies at the origin since this can lead to many
+  /// overlapping [Shape]s.
   Vector2 position;
 
   /// The world angle of the body in radians.
@@ -41,31 +48,40 @@ class BodyDef {
   /// The angular velocity of the body.
   double angularVelocity;
 
-  /// Linear damping is use to reduce the linear velocity. The damping parameter can be larger than
-  /// 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
-  /// large.
+  /// Linear damping is use to reduce the linear velocity.
+  ///
+  /// The damping parameter can be larger than 1.0f but the damping effect
+  /// becomes sensitive to the time step when the damping parameter is large.
   double linearDamping;
 
-  /// Angular damping is use to reduce the angular velocity. The damping parameter can be larger than
-  /// 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
-  /// large.
+  /// Angular damping is use to reduce the angular velocity.
+  ///
+  /// The damping parameter can be larger than 1.0f but the damping effect
+  /// becomes sensitive to the time step when the damping parameter is large.
   double angularDamping;
 
-  /// Set this flag to false if this body should never fall asleep. Note that this increases CPU
-  /// usage.
+  /// Set this flag to false if this body should never fall asleep.
+  ///
+  /// Note: Not alllowing a body to sleep increases CPU usage.
   bool allowSleep;
 
   /// Is this body initially sleeping?
   bool isAwake;
 
-  /// Should this body be prevented from rotating? Useful for characters.
+  /// Should this body be prevented from rotating?
+  ///
+  /// Useful for characters.
   bool fixedRotation;
 
-  /// Is this a fast moving body that should be prevented from tunneling through other moving bodies?
-  /// Note that all bodies are prevented from tunneling through kinematic and static bodies. This
-  /// setting is only considered on dynamic bodies.
+  /// Is this a fast moving body that should be prevented from tunneling through
+  /// other moving bodies?
   ///
-  /// @warning You should use this flag sparingly since it increases processing time.
+  /// Note: All bodies are prevented from tunneling through [BodyType.kinematic]
+  /// and [BodyType.static] bodies. This setting is only considered on
+  /// [BodyType.dynamic] bodies.
+  ///
+  /// Warning: You should use this flag sparingly since it increases processing
+  /// time.
   bool bullet;
 
   /// Does this body start out active?

--- a/packages/forge2d/lib/src/dynamics/body_type.dart
+++ b/packages/forge2d/lib/src/dynamics/body_type.dart
@@ -1,5 +1,17 @@
-/// The body type.
-/// static: zero mass, zero velocity, may be manually moved
-/// kinematic: zero mass, non-zero velocity set by user, moved by solver
-/// dynamic: positive mass, non-zero velocity determined by forces, moved by solver
-enum BodyType { static, kinematic, dynamic }
+import '../../forge2d.dart';
+
+/// {@template dynamics.body_type}
+/// Defines the type of a [Body].
+/// {@endtemplate}
+enum BodyType {
+  /// Defines a [Body] with zero mass, zero velocity, may be manually moved.
+  static,
+
+  /// Defines a [Body] with zero mass, non-zero velocity set by user, moved by
+  /// solver.
+  kinematic,
+
+  /// Defines a [Body] with positive mass, non-zero velocity determined by
+  /// forces, moved by solver.
+  dynamic,
+}

--- a/packages/forge2d/test/dynamics/body_def_test.dart
+++ b/packages/forge2d/test/dynamics/body_def_test.dart
@@ -1,0 +1,10 @@
+import 'package:forge2d/forge2d.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BodyDef', () {
+    test('can be instantiated', () {
+      expect(BodyDef(), isA<BodyDef>());
+    });
+  });
+}


### PR DESCRIPTION
# Description

Allowed specifying BodyDef properties via the constructor.

The main benefit of this change is that when setting values to default values they get picked up by [avoid_redundant_argument_values](https://dart-lang.github.io/linter/lints/avoid_redundant_argument_values.html).

```dart
BodyDef()..type = BodyType.static; // Linter doesn't complain.

BodyDef(type: BodyType.static); // Linter complains with avoid_redundant_argument_values
```

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

## Related Issues

#33 

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org