### PR TITLE
feat: allowed specifying `FixtureDef` properties via constructor #51

### DIFF
--- a/packages/forge2d/lib/src/dynamics/fixture_def.dart
+++ b/packages/forge2d/lib/src/dynamics/fixture_def.dart
@@ -7,7 +7,7 @@ class FixtureDef {
   FixtureDef(
     this.shape, {
     this.userData,
-    this.friction = 0.2,
+    this.friction = 0,
     this.restitution = 0,
     this.density = 0,
     this.isSensor = false,

--- a/packages/forge2d/lib/src/dynamics/fixture_def.dart
+++ b/packages/forge2d/lib/src/dynamics/fixture_def.dart
@@ -1,29 +1,41 @@
 import '../../forge2d.dart';
 
-/// A fixture definition is used to create a fixture. This class defines an abstract fixture
-/// definition. You can reuse fixture definitions safely.
+/// Used to create a [Fixture].
+///
+/// You can reuse fixture definitions safely.
 class FixtureDef {
-  /// The shape, this must be set. The shape will be cloned, so you can create the shape on the
+  FixtureDef(
+    this.shape, {
+    this.userData,
+    this.friction = 0.2,
+    this.restitution = 0,
+    this.density = 0,
+    this.isSensor = false,
+    Filter? filter,
+  }) : filter = filter ?? Filter();
+
+  /// The [Shape], this must be set.
+  ///
+  /// The [Shape] will be [Shape.clone]d, so you can create the shape on the
   /// stack.
   Shape shape;
-
-  FixtureDef(this.shape);
 
   /// Use this to store application specific fixture data.
   Object? userData;
 
   /// The friction coefficient, usually in the range [0,1].
-  double friction = 0.2;
+  double friction;
 
   /// The restitution (elasticity) usually in the range [0,1].
-  double restitution = 0.0;
+  double restitution;
 
-  /// The density, usually in kg/m^2
-  double density = 0.0;
+  /// The density, usually in kg/m^2.
+  double density;
 
-  /// A sensor shape collects contact information but never generates a collision response.
-  bool isSensor = false;
+  /// A sensor shape collects contact information but never generates a
+  /// collision response.
+  bool isSensor;
 
-  /// Contact filtering data;
-  Filter filter = Filter();
+  /// Contact filtering data.
+  Filter filter;
 }

--- a/packages/forge2d/test/dynamics/fixture_def_test.dart
+++ b/packages/forge2d/test/dynamics/fixture_def_test.dart
@@ -1,0 +1,24 @@
+import 'package:forge2d/forge2d.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FixtureDef', () {
+    group('can be instantiated', () {
+      test('when Shape is a ChainShape', () {
+        expect(FixtureDef(ChainShape()), isA<FixtureDef>());
+      });
+
+      test('when Shape is a CircleShape', () {
+        expect(FixtureDef(CircleShape()), isA<FixtureDef>());
+      });
+
+      test('when Shape is a EdgeShape', () {
+        expect(FixtureDef(EdgeShape()), isA<FixtureDef>());
+      });
+
+      test('when Shape is a PolygonShape', () {
+        expect(FixtureDef(PolygonShape()), isA<FixtureDef>());
+      });
+    });
+  });
+}


### PR DESCRIPTION
# Description

Allowed specifying `FixtureDef` properties via the constructor.

The main benefit of this change is that when setting values to default values they get picked up by [avoid_redundant_argument_values](https://dart-lang.github.io/linter/lints/avoid_redundant_argument_values.html).

```dart
FixtureDef()..restitution = 0; // Linter doesn't complain.

FixtureDef(restitution: 0); // Linter complains with avoid_redundant_argument_values
```

In addition, it updates the `friction` default to 0 instead of 0.2.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Related Issues

#33 

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org