### PR TITLE
fix!: Add friction and restitution arguments to createFixtureFromShape

### DIFF
--- a/packages/benchmark/web/bench2d.dart
+++ b/packages/benchmark/web/bench2d.dart
@@ -65,7 +65,7 @@ class Bench2d {
         final bd = BodyDef()
           ..type = BodyType.dynamic
           ..position.setFrom(y);
-        world.createBody(bd).createFixtureFromShape(shape, 5.0);
+        world.createBody(bd).createFixtureFromShape(shape, density: 5.0);
         y.add(deltaY);
       }
 

--- a/packages/forge2d/example/web/blob_test.dart
+++ b/packages/forge2d/example/web/blob_test.dart
@@ -74,7 +74,7 @@ class BlobTest extends Demo {
     psd.setAsBox(3.0, 1.5, Vector2(cx, cy + 15.0), 0.0);
     bd2.position = Vector2(cx, cy + 15.0);
     final fallingBox = world.createBody(bd2);
-    fallingBox.createFixtureFromShape(psd, 1.0);
+    fallingBox.createFixtureFromShape(psd, density: 1.0);
   }
 }
 

--- a/packages/forge2d/example/web/racer/car.dart
+++ b/packages/forge2d/example/web/racer/car.dart
@@ -40,7 +40,7 @@ class Car {
 
     final shape = PolygonShape()..set(vertices);
 
-    _body.createFixtureFromShape(shape, 0.1);
+    _body.createFixtureFromShape(shape, density: 0.1);
 
     final jointDef = RevoluteJointDef();
     jointDef.bodyA = _body;

--- a/packages/forge2d/example/web/racer/tire.dart
+++ b/packages/forge2d/example/web/racer/tire.dart
@@ -20,7 +20,7 @@ class Tire {
 
     final polygonShape = PolygonShape();
     polygonShape.setAsBoxXY(0.5, 1.25);
-    final fixture = body.createFixtureFromShape(polygonShape, 1.0);
+    final fixture = body.createFixtureFromShape(polygonShape, density: 1.0);
     fixture.userData = this;
 
     _currentTraction = 1.0;

--- a/packages/forge2d/lib/src/dynamics/body.dart
+++ b/packages/forge2d/lib/src/dynamics/body.dart
@@ -170,7 +170,7 @@ class Body {
   /// @warning This function is locked during callbacks.
   Fixture createFixtureFromShape(
     Shape shape, {
-    double density = 0.0,
+    double density = 1.0,
     double friction = 0.0,
     double restitution = 0.0,
   }) {

--- a/packages/forge2d/lib/src/dynamics/body.dart
+++ b/packages/forge2d/lib/src/dynamics/body.dart
@@ -168,8 +168,18 @@ class Body {
   /// @param shape the shape to be cloned.
   /// @param density the shape density (set to zero for static bodies).
   /// @warning This function is locked during callbacks.
-  Fixture createFixtureFromShape(Shape shape, [double density = 0.0]) {
-    return createFixture(FixtureDef(shape)..density = density);
+  Fixture createFixtureFromShape(
+    Shape shape, {
+    double density = 0.0,
+    double friction = 0.0,
+    double restitution = 0.0,
+  }) {
+    return createFixture(
+      FixtureDef(shape)
+        ..density = density
+        ..friction = friction
+        ..restitution = restitution,
+    );
   }
 
   /// Destroy a fixture. This removes the fixture from the broad-phase and destroys all contacts

--- a/packages/forge2d/lib/src/dynamics/fixture_def.dart
+++ b/packages/forge2d/lib/src/dynamics/fixture_def.dart
@@ -9,7 +9,7 @@ class FixtureDef {
     this.userData,
     this.friction = 0,
     this.restitution = 0,
-    this.density = 0,
+    this.density = 1,
     this.isSensor = false,
     Filter? filter,
   }) : filter = filter ?? Filter();


### PR DESCRIPTION
# Description

Just adding the two missing arguments to `createFixtureFromShape`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

This is breaking since it makes no sense in having positional arguments here, so I converted them to named arguments.

- [x] Yes, this is a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org