### PR TITLE
fix: Properly use the `getX/YAxis` out vector

### DIFF
--- a/packages/forge2d/lib/src/common/rot.dart
+++ b/packages/forge2d/lib/src/common/rot.dart
@@ -36,9 +36,15 @@ class Rot {
 
   double getAngle() => math.atan2(sin, cos);
 
-  Vector2 getXAxis(Vector2 xAxis) => Vector2(cos, sin);
+  Vector2 getXAxis({Vector2? out}) {
+    final result = out ?? Vector2.zero();
+    return result..setValues(cos, sin);
+  }
 
-  Vector2 getYAxis(Vector2 yAxis) => Vector2(-sin, cos);
+  Vector2 getYAxis({Vector2? out}) {
+    final result = out ?? Vector2.zero();
+    return result..setValues(-sin, cos);
+  }
 
   Rot clone() => Rot(sin: sin, cos: cos);
 

--- a/packages/forge2d/lib/src/dynamics/fixture.dart
+++ b/packages/forge2d/lib/src/dynamics/fixture.dart
@@ -4,10 +4,10 @@ import 'package:forge2d/forge2d.dart';
 import 'package:forge2d/src/settings.dart' as settings;
 import 'package:meta/meta.dart';
 
-/// A fixture is used to attach a shape to a body for collision detection. A
+/// A fixture is used to attach a [Shape] to a [Body] for collision detection. A
 /// fixture inherits its transform from its parent. Fixtures hold additional
 /// non-geometric data such as friction, collision filters, etc. Fixtures are
-/// created via Body::CreateFixture.
+/// created via `body.createFixture`.
 ///
 /// Do note that you cannot reuse fixtures.
 class Fixture {
@@ -249,7 +249,7 @@ class Fixture {
 
           renderCenter.setFrom(Transform.mulVec2(xf, circle.position));
           final radius = circle.radius;
-          xf.q.getXAxis(renderAxis);
+          xf.q.getXAxis(out: renderAxis);
 
           if (userData != null && userData == liquidFlag) {
             _liquidOffset.setFrom(body.linearVelocity);


### PR DESCRIPTION
# Description

Previously a vector was sent in to the methods, but it wasn't used.
This PR makes that vector optional and makes use of it.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [x] Yes, this is a breaking change, doubt that anyone is using this class manually though.

## Related Issues

Closes #60 

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org