### PR TITLE
refactor!: removed wrapper get and set methods for GearJoint.ratio

### DIFF
--- a/packages/forge2d/lib/src/dynamics/joints/gear_joint.dart
+++ b/packages/forge2d/lib/src/dynamics/joints/gear_joint.dart
@@ -48,7 +48,7 @@ class GearJoint extends Joint {
   double _referenceAngleB = 0.0;
 
   double _constant = 0.0;
-  double _ratio = 0.0;
+  double ratio = 0.0;
 
   double _impulse = 0.0;
 
@@ -148,8 +148,8 @@ class GearJoint extends Joint {
       coordinateB = (pB..sub(pD)).dot(_localAxisD);
     }
 
-    _ratio = def.ratio;
-    _constant = coordinateA + _ratio * coordinateB;
+    ratio = def.ratio;
+    _constant = coordinateA + ratio * coordinateB;
     _impulse = 0.0;
   }
 
@@ -164,14 +164,6 @@ class GearJoint extends Joint {
   @override
   double reactionTorque(double invDt) {
     return invDt * _impulse * _jwA;
-  }
-
-  void setRatio(double argRatio) {
-    _ratio = argRatio;
-  }
-
-  double getRatio() {
-    return _ratio;
   }
 
   @override
@@ -250,9 +242,9 @@ class GearJoint extends Joint {
 
     if (_joint2 is RevoluteJoint) {
       _jvBD.setZero();
-      _jwB = _ratio;
-      _jwD = _ratio;
-      _mass += _ratio * _ratio * (_iB + _iD);
+      _jwB = ratio;
+      _jwD = ratio;
+      _mass += ratio * ratio * (_iB + _iD);
     } else {
       final u = Vector2.zero();
       final rD = Vector2.zero();
@@ -268,11 +260,11 @@ class GearJoint extends Joint {
       rB.setFrom(Rot.mulVec2(qB, temp));
       _jvBD
         ..setFrom(u)
-        ..scale(_ratio);
-      _jwD = _ratio * rD.cross(u);
-      _jwB = _ratio * rB.cross(u);
+        ..scale(ratio);
+      _jwD = ratio * rD.cross(u);
+      _jwB = ratio * rB.cross(u);
       _mass +=
-          _ratio * _ratio * (_mD + _mB) + _iD * _jwD * _jwD + _iB * _jwB * _jwB;
+          ratio * ratio * (_mD + _mB) + _iD * _jwD * _jwD + _iB * _jwB * _jwB;
     }
 
     // Compute effective mass.
@@ -435,9 +427,9 @@ class GearJoint extends Joint {
 
     if (_joint2 is RevoluteJoint) {
       jvBD.setZero();
-      jwB = _ratio;
-      jwD = _ratio;
-      mass += _ratio * _ratio * (_iB + _iD);
+      jwB = ratio;
+      jwD = ratio;
+      mass += ratio * ratio * (_iB + _iD);
 
       coordinateB = aB - aD - _referenceAngleB;
     } else {
@@ -457,10 +449,10 @@ class GearJoint extends Joint {
       rB.setFrom(Rot.mulVec2(qB, temp));
       jvBD
         ..setFrom(u)
-        ..scale(_ratio);
+        ..scale(ratio);
       jwD = rD.cross(u);
       jwB = rB.cross(u);
-      mass += _ratio * _ratio * (_mD + _mB) + _iD * jwD * jwD + _iB * jwB * jwB;
+      mass += ratio * ratio * (_mD + _mB) + _iD * jwD * jwD + _iB * jwB * jwB;
 
       pD
         ..setFrom(_localAnchorD)
@@ -473,7 +465,7 @@ class GearJoint extends Joint {
       coordinateB = (pB..sub(pD)).dot(_localAxisD);
     }
 
-    final c = (coordinateA + _ratio * coordinateB) - _constant;
+    final c = (coordinateA + ratio * coordinateB) - _constant;
 
     var impulse = 0.0;
     if (mass > 0.0) {


### PR DESCRIPTION
# Description

Removes `setRatio` and `getRatio` which were only wrapping around `ratio`.

```dart
// Before
gearJoint.setRatio(0.2)
geatJoint.getRatio() // 0.2

// After
geatJoint.ratio = 0.2
geatJoint.ratio; // 0.2
```

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [X] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org