### PR TITLE
refactor!: bullet getter and setter

### DIFF
--- a/packages/forge2d/example/web/circle_stress.dart
+++ b/packages/forge2d/example/web/circle_stress.dart
@@ -122,7 +122,7 @@ class CircleStress extends Demo {
         body.createFixture(fixtureDef);
       }
 
-      body.bullet = false;
+      body.isBullet = false;
 
       // Create an empty ground body.
       final bodyDef = BodyDef();

--- a/packages/forge2d/example/web/circle_stress.dart
+++ b/packages/forge2d/example/web/circle_stress.dart
@@ -122,7 +122,7 @@ class CircleStress extends Demo {
         body.createFixture(fixtureDef);
       }
 
-      body.setBullet(false);
+      body.bullet = false;
 
       // Create an empty ground body.
       final bodyDef = BodyDef();

--- a/packages/forge2d/lib/src/dynamics/body.dart
+++ b/packages/forge2d/lib/src/dynamics/body.dart
@@ -598,11 +598,21 @@ class Body {
     }
   }
 
-  /// Is this body treated like a bullet for continuous collision detection?
-  bool get isBullet => (flags & bulletFlag) == bulletFlag;
-
+  /// {@template isBullet}
   /// Whether this body should be treated like a bullet for continuous collision
   /// detection.
+  ///
+  /// Fast moving dynamic bodies should be labeled as bullets so that they
+  /// do not tunnel through other moving objects.
+  ///
+  /// **Warning:** You should use this flag sparingly since it increases
+  /// processing time.
+  ///
+  /// See also:
+  ///
+  /// * [Box2D bullets documentation](https://box2d.org/documentation/md__d_1__git_hub_box2d_docs_dynamics.html)
+  /// * [Box2D bullet method definition](https://box2d.org/documentation/structb2_body_def.html#a7c0047c9a98a1d20614eeddcdbce7586)
+  /// {@endtemplate}
   set isBullet(bool flag) {
     if (flag) {
       flags |= bulletFlag;
@@ -610,6 +620,9 @@ class Body {
       flags &= ~bulletFlag;
     }
   }
+
+  /// {@macro isBullet}
+  bool get isBullet => (flags & bulletFlag) == bulletFlag;
 
   /// You can disable sleeping on this body. If you disable sleeping, the body
   /// will be woken.

--- a/packages/forge2d/lib/src/dynamics/body.dart
+++ b/packages/forge2d/lib/src/dynamics/body.dart
@@ -610,12 +610,10 @@ class Body {
   }
 
   /// Is this body treated like a bullet for continuous collision detection?
-  bool isBullet() {
-    return (flags & bulletFlag) == bulletFlag;
-  }
+  bool get bullet => (flags & bulletFlag) == bulletFlag;
 
   /// Should this body be treated like a bullet for continuous collision detection?
-  void setBullet(bool flag) {
+  set bullet(bool flag) {
     if (flag) {
       flags |= bulletFlag;
     } else {

--- a/packages/forge2d/lib/src/dynamics/body.dart
+++ b/packages/forge2d/lib/src/dynamics/body.dart
@@ -611,7 +611,7 @@ class Body {
   /// See also:
   ///
   /// * [Box2D bullets documentation](https://box2d.org/documentation/md__d_1__git_hub_box2d_docs_dynamics.html)
-  /// * [Box2D bullet method definition](https://box2d.org/documentation/structb2_body_def.html#a7c0047c9a98a1d20614eeddcdbce7586)
+  /// * [Box2D bullet member data definition](https://box2d.org/documentation/structb2_body_def.html#a7c0047c9a98a1d20614eeddcdbce7586)
   /// {@endtemplate}
   set isBullet(bool flag) {
     if (flag) {

--- a/packages/forge2d/lib/src/dynamics/body.dart
+++ b/packages/forge2d/lib/src/dynamics/body.dart
@@ -599,11 +599,11 @@ class Body {
   }
 
   /// Is this body treated like a bullet for continuous collision detection?
-  bool get bullet => (flags & bulletFlag) == bulletFlag;
+  bool get isBullet => (flags & bulletFlag) == bulletFlag;
 
   /// Whether this body should be treated like a bullet for continuous collision
   /// detection.
-  void setBullet(bool flag) {
+  set isBullet(bool flag) {
     if (flag) {
       flags |= bulletFlag;
     } else {

--- a/packages/forge2d/lib/src/dynamics/world.dart
+++ b/packages/forge2d/lib/src/dynamics/world.dart
@@ -723,8 +723,8 @@ class World {
             continue;
           }
 
-          final collideA = bodyA.bullet || typeA != BodyType.dynamic;
-          final collideB = bodyB.bullet || typeB != BodyType.dynamic;
+          final collideA = bodyA.isBullet || typeA != BodyType.dynamic;
+          final collideB = bodyB.isBullet || typeB != BodyType.dynamic;
 
           // Are these two non-bullet dynamic bodies?
           if (collideA == false && collideB == false) {
@@ -838,8 +838,8 @@ class World {
             // Only add static, kinematic, or bullet bodies.
             final other = contact.getOtherBody(body);
             if (other.bodyType == BodyType.dynamic &&
-                body.bullet == false &&
-                other.bullet == false) {
+                body.isBullet == false &&
+                other.isBullet == false) {
               continue;
             }
 

--- a/packages/forge2d/lib/src/dynamics/world.dart
+++ b/packages/forge2d/lib/src/dynamics/world.dart
@@ -731,8 +731,8 @@ class World {
             continue;
           }
 
-          final collideA = bodyA.isBullet() || typeA != BodyType.dynamic;
-          final collideB = bodyB.isBullet() || typeB != BodyType.dynamic;
+          final collideA = bodyA.bullet || typeA != BodyType.dynamic;
+          final collideB = bodyB.bullet || typeB != BodyType.dynamic;
 
           // Are these two non-bullet dynamic bodies?
           if (collideA == false && collideB == false) {
@@ -842,8 +842,8 @@ class World {
             // Only add static, kinematic, or bullet bodies.
             final other = contact.getOtherBody(body);
             if (other.bodyType == BodyType.dynamic &&
-                body.isBullet() == false &&
-                other.isBullet() == false) {
+                body.bullet == false &&
+                other.bullet == false) {
               continue;
             }
 

--- a/packages/forge2d/lib/src/dynamics/world.dart
+++ b/packages/forge2d/lib/src/dynamics/world.dart
@@ -838,8 +838,8 @@ class World {
             // Only add static, kinematic, or bullet bodies.
             final other = contact.getOtherBody(body);
             if (other.bodyType == BodyType.dynamic &&
-                body.isBullet == false &&
-                other.isBullet == false) {
+                !body.isBullet &&
+                !other.isBullet) {
               continue;
             }
 

--- a/packages/forge2d/test/dynamics/body_test.dart
+++ b/packages/forge2d/test/dynamics/body_test.dart
@@ -9,11 +9,11 @@ void main() {
       test('can change', () {
         final body = Body(BodyDef(), World());
         const newBulletValue = true;
-        expect(body.bullet, isNot(equals(newBulletValue)));
+        expect(body.isBullet, isNot(equals(newBulletValue)));
 
-        body.bullet = newBulletValue;
+        body.isBullet = newBulletValue;
 
-        expect(body.bullet, equals(newBulletValue));
+        expect(body.isBullet, equals(newBulletValue));
       });
     });
 

--- a/packages/forge2d/test/dynamics/body_test.dart
+++ b/packages/forge2d/test/dynamics/body_test.dart
@@ -1,9 +1,22 @@
 import 'package:forge2d/forge2d.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
 void main() {
   group('Body', () {
+    group('bullet', () {
+      test('can change', () {
+        final body = Body(BodyDef(), World());
+        const newBulletValue = true;
+        expect(body.bullet, isNot(equals(newBulletValue)));
+
+        body.bullet = newBulletValue;
+
+        expect(body.bullet, equals(newBulletValue));
+      });
+    });
+
     group('gravityOverride', () {
       test("body doesn't move when is zero", () {
         final gravity = Vector2(10, 10);

--- a/packages/forge2d/test/dynamics/body_test.dart
+++ b/packages/forge2d/test/dynamics/body_test.dart
@@ -5,7 +5,12 @@ import 'package:test/scaffolding.dart';
 
 void main() {
   group('Body', () {
-    group('bullet', () {
+    group('isBullet', () {
+      test('is false by default', () {
+        final body = Body(BodyDef(), World());
+        expect(body.isBullet, equals(false));
+      });
+
       test('can change', () {
         final body = Body(BodyDef(), World());
         const newBulletValue = true;

--- a/packages/forge2d/test/dynamics/body_test.dart
+++ b/packages/forge2d/test/dynamics/body_test.dart
@@ -1,5 +1,4 @@
 import 'package:forge2d/forge2d.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 


### PR DESCRIPTION
# Description

Removes `setBullet` and `isBullet` in favour of setter and getters.

```dart
// Before:
body.setBullet(true);
body.isBullet(); // true

// After:
body.isBullet = true;
body.isBullet; // true
```

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [X] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org