### PR TITLE
refactor!: `isEnabled` getter and setter

### DIFF
--- a/packages/forge2d/lib/src/callbacks/contact_listener.dart
+++ b/packages/forge2d/lib/src/callbacks/contact_listener.dart
@@ -11,10 +11,10 @@ import '../../forge2d.dart';
 /// @warning You cannot create/destroy Forge2D entities inside these callbacks.
 abstract class ContactListener {
   /// Called when two fixtures begin to touch.
-  void beginContact(Contact contact);
+  void beginContact(Contact contact) {}
 
   /// Called when two fixtures cease to touch.
-  void endContact(Contact contact);
+  void endContact(Contact contact) {}
 
   /// This is called after a contact is updated. This allows you to inspect a
   /// contact before it goes to the solver. If you are careful, you can modify the
@@ -28,7 +28,7 @@ abstract class ContactListener {
   /// the next step.
   /// Note: the oldManifold parameter is pooled, so it will be the same object for every callback
   /// for each thread.
-  void preSolve(Contact contact, Manifold oldManifold);
+  void preSolve(Contact contact, Manifold oldManifold) {}
 
   /// This lets you inspect a contact after the solver is finished. This is useful
   /// for inspecting impulses.
@@ -38,5 +38,5 @@ abstract class ContactListener {
   /// Note: this is only called for contacts that are touching, solid, and awake.
   /// @param contact
   /// @param impulse this is usually a pooled variable, so it will be modified after this call
-  void postSolve(Contact contact, ContactImpulse impulse);
+  void postSolve(Contact contact, ContactImpulse impulse) {}
 }

--- a/packages/forge2d/lib/src/dynamics/contacts/contact.dart
+++ b/packages/forge2d/lib/src/dynamics/contacts/contact.dart
@@ -162,8 +162,11 @@ abstract class Contact {
             this.indexB == indexA);
   }
 
-  /// Enable/disable this contact. This can be used inside the pre-solve contact listener. The
-  /// contact is only disabled for the current time step (or sub-step in continuous collisions).
+  /// Enable or disable this contact.
+  ///
+  /// This can be used inside [ContactListener.preSolve]. The contact is
+  /// only disabled for the current time step (or sub-step in continuous
+  /// collisions).
   set enabled(bool enable) {
     if (enable) {
       flags |= enabledFlag;
@@ -172,7 +175,7 @@ abstract class Contact {
     }
   }
 
-  /// Has this contact been disabled?
+  /// Whether this contact is enabled.
   bool get enabled => (flags & enabledFlag) == enabledFlag;
 
   void resetFriction() {

--- a/packages/forge2d/lib/src/dynamics/contacts/contact.dart
+++ b/packages/forge2d/lib/src/dynamics/contacts/contact.dart
@@ -167,8 +167,8 @@ abstract class Contact {
   /// This can be used inside [ContactListener.preSolve]. The contact is
   /// only disabled for the current time step (or sub-step in continuous
   /// collisions).
-  set enabled(bool enable) {
-    if (enable) {
+  set isEnabled(bool value) {
+    if (value) {
       flags |= enabledFlag;
     } else {
       flags &= ~enabledFlag;
@@ -176,7 +176,7 @@ abstract class Contact {
   }
 
   /// Whether this contact is enabled.
-  bool get enabled => (flags & enabledFlag) == enabledFlag;
+  bool get isEnabled => (flags & enabledFlag) == enabledFlag;
 
   void resetFriction() {
     _friction = Contact.mixFriction(fixtureA.friction, fixtureB.friction);

--- a/packages/forge2d/lib/src/dynamics/contacts/contact.dart
+++ b/packages/forge2d/lib/src/dynamics/contacts/contact.dart
@@ -164,7 +164,7 @@ abstract class Contact {
 
   /// Enable/disable this contact. This can be used inside the pre-solve contact listener. The
   /// contact is only disabled for the current time step (or sub-step in continuous collisions).
-  void setEnabled(bool enable) {
+  set enabled(bool enable) {
     if (enable) {
       flags |= enabledFlag;
     } else {
@@ -173,7 +173,7 @@ abstract class Contact {
   }
 
   /// Has this contact been disabled?
-  bool isEnabled() => (flags & enabledFlag) == enabledFlag;
+  bool get enabled => (flags & enabledFlag) == enabledFlag;
 
   void resetFriction() {
     _friction = Contact.mixFriction(fixtureA.friction, fixtureB.friction);

--- a/packages/forge2d/lib/src/dynamics/world.dart
+++ b/packages/forge2d/lib/src/dynamics/world.dart
@@ -578,7 +578,7 @@ class World {
           }
 
           // Is this contact solid and touching?
-          if (contact.isEnabled() == false || contact.isTouching() == false) {
+          if (contact.enabled == false || contact.isTouching() == false) {
             continue;
           }
 
@@ -694,7 +694,7 @@ class World {
 
       for (final contact in contactManager.contacts) {
         // Is this contact disabled?
-        if (contact.isEnabled() == false) {
+        if (contact.enabled == false) {
           continue;
         }
 
@@ -807,9 +807,9 @@ class World {
       ++minContact.toiCount;
 
       // Is the contact solid?
-      if (minContact.isEnabled() == false || minContact.isTouching() == false) {
+      if (minContact.enabled == false || minContact.isTouching() == false) {
         // Restore the sweeps.
-        minContact.setEnabled(false);
+        minContact.enabled = false;
         bodyA.sweep.set(_backup1);
         bodyB.sweep.set(_backup2);
         bodyA.synchronizeTransform();
@@ -864,7 +864,7 @@ class World {
             contact.update(contactManager.contactListener);
 
             // Was the contact disabled by the user?
-            if (contact.isEnabled() == false) {
+            if (contact.enabled == false) {
               other.sweep.set(_backup1);
               other.synchronizeTransform();
               continue;

--- a/packages/forge2d/lib/src/dynamics/world.dart
+++ b/packages/forge2d/lib/src/dynamics/world.dart
@@ -578,7 +578,7 @@ class World {
           }
 
           // Is this contact solid and touching?
-          if (contact.enabled == false || contact.isTouching() == false) {
+          if (contact.isEnabled == false || contact.isTouching() == false) {
             continue;
           }
 
@@ -694,7 +694,7 @@ class World {
 
       for (final contact in contactManager.contacts) {
         // Is this contact disabled?
-        if (contact.enabled == false) {
+        if (contact.isEnabled == false) {
           continue;
         }
 
@@ -807,9 +807,9 @@ class World {
       ++minContact.toiCount;
 
       // Is the contact solid?
-      if (minContact.enabled == false || minContact.isTouching() == false) {
+      if (minContact.isEnabled == false || minContact.isTouching() == false) {
         // Restore the sweeps.
-        minContact.enabled = false;
+        minContact.isEnabled = false;
         bodyA.sweep.set(_backup1);
         bodyB.sweep.set(_backup2);
         bodyA.synchronizeTransform();
@@ -864,7 +864,7 @@ class World {
             contact.update(contactManager.contactListener);
 
             // Was the contact disabled by the user?
-            if (contact.enabled == false) {
+            if (contact.isEnabled == false) {
               other.sweep.set(_backup1);
               other.synchronizeTransform();
               continue;

--- a/packages/forge2d/test/dynamics/contacts/contact_test.dart
+++ b/packages/forge2d/test/dynamics/contacts/contact_test.dart
@@ -7,16 +7,11 @@ class _MockFixture extends Mock implements Fixture {}
 
 class _TestContact extends Contact {
   _TestContact(
-    Fixture fixtureA,
-    int indexA,
-    Fixture fixtureB,
-    int indexB,
-  ) : super(
-          fixtureA,
-          indexA,
-          fixtureB,
-          indexB,
-        );
+    super.fixtureA,
+    super.indexA,
+    super.fixtureB,
+    super.indexB,
+  );
 
   @override
   void evaluate(_, __, ___) => throw UnimplementedError();

--- a/packages/forge2d/test/dynamics/contacts/contact_test.dart
+++ b/packages/forge2d/test/dynamics/contacts/contact_test.dart
@@ -48,8 +48,8 @@ void mian() {
       );
     });
 
-    group('enabled', () {
-      test('enabled by default', () {
+    group('isEnabled', () {
+      test('true by default', () {
         final contact = _TestContact(
           fixtureA,
           indexA,
@@ -57,7 +57,7 @@ void mian() {
           indexB,
         );
 
-        expect(contact.enabled, isTrue);
+        expect(contact.isEnabled, isTrue);
       });
 
       test('can change', () {
@@ -68,10 +68,10 @@ void mian() {
           indexB,
         );
 
-        final newEnabled = !contact.enabled;
-        contact.enabled = newEnabled;
+        final newEnabled = !contact.isEnabled;
+        contact.isEnabled = newEnabled;
 
-        expect(contact.enabled, equals(newEnabled));
+        expect(contact.isEnabled, equals(newEnabled));
       });
     });
   });

--- a/packages/forge2d/test/dynamics/contacts/contact_test.dart
+++ b/packages/forge2d/test/dynamics/contacts/contact_test.dart
@@ -1,7 +1,78 @@
+import 'package:forge2d/forge2d_browser.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
+
+class _MockFixture extends Mock implements Fixture {}
+
+class _TestContact extends Contact {
+  _TestContact(
+    Fixture fixtureA,
+    int indexA,
+    Fixture fixtureB,
+    int indexB,
+  ) : super(
+          fixtureA,
+          indexA,
+          fixtureB,
+          indexB,
+        );
+
+  @override
+  void evaluate(_, __, ___) => throw UnimplementedError();
+}
 
 void mian() {
   group('Contact', () {
-    group('enabled', () {});
+    late Fixture fixtureA;
+    late int indexA;
+    late Fixture fixtureB;
+    late int indexB;
+
+    setUp(() {
+      fixtureA = _MockFixture();
+      indexA = 0;
+      fixtureB = _MockFixture();
+      indexB = 0;
+    });
+
+    test('can be instantiated', () {
+      expect(
+        _TestContact(
+          fixtureA,
+          indexA,
+          fixtureB,
+          indexB,
+        ),
+        isA<Contact>(),
+      );
+    });
+
+    group('enabled', () {
+      test('enabled by default', () {
+        final contact = _TestContact(
+          fixtureA,
+          indexA,
+          fixtureB,
+          indexB,
+        );
+
+        expect(contact.enabled, isTrue);
+      });
+
+      test('can change', () {
+        final contact = _TestContact(
+          fixtureA,
+          indexA,
+          fixtureB,
+          indexB,
+        );
+
+        final newEnabled = !contact.enabled;
+        contact.enabled = newEnabled;
+
+        expect(contact.enabled, equals(newEnabled));
+      });
+    });
   });
 }

--- a/packages/forge2d/test/dynamics/contacts/contact_test.dart
+++ b/packages/forge2d/test/dynamics/contacts/contact_test.dart
@@ -1,7 +1,6 @@
-import 'package:forge2d/forge2d_browser.dart';
+import 'package:forge2d/forge2d.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:test/expect.dart';
-import 'package:test/scaffolding.dart';
+import 'package:test/test.dart';
 
 class _MockFixture extends Mock implements Fixture {}
 

--- a/packages/forge2d/test/dynamics/contacts/contact_test.dart
+++ b/packages/forge2d/test/dynamics/contacts/contact_test.dart
@@ -1,0 +1,7 @@
+import 'package:test/scaffolding.dart';
+
+void mian() {
+  group('Contact', () {
+    group('enabled', () {});
+  });
+}

--- a/packages/forge2d/test/dynamics/contacts/contact_test.dart
+++ b/packages/forge2d/test/dynamics/contacts/contact_test.dart
@@ -16,7 +16,7 @@ class _TestContact extends Contact {
   void evaluate(_, __, ___) => throw UnimplementedError();
 }
 
-void mian() {
+void main() {
   group('Contact', () {
     late Fixture fixtureA;
     late int indexA;

--- a/packages/forge2d/test/dynamics/contacts/contact_test.dart
+++ b/packages/forge2d/test/dynamics/contacts/contact_test.dart
@@ -68,10 +68,10 @@ void mian() {
           indexB,
         );
 
-        final newEnabled = !contact.isEnabled;
-        contact.isEnabled = newEnabled;
+        final newIsEnabled = !contact.isEnabled;
+        contact.isEnabled = newIsEnabled;
 
-        expect(contact.isEnabled, equals(newEnabled));
+        expect(contact.isEnabled, equals(newIsEnabled));
       });
     });
   });

--- a/packages/forge2d/test/dynamics/contacts/contact_test.dart
+++ b/packages/forge2d/test/dynamics/contacts/contact_test.dart
@@ -25,8 +25,14 @@ void main() {
 
     setUp(() {
       fixtureA = _MockFixture();
-      indexA = 0;
+      when(() => fixtureA.friction).thenReturn(0);
+      when(() => fixtureA.restitution).thenReturn(0);
+
       fixtureB = _MockFixture();
+      when(() => fixtureB.friction).thenReturn(0);
+      when(() => fixtureB.restitution).thenReturn(0);
+
+      indexA = 0;
       indexB = 0;
     });
 


### PR DESCRIPTION
# Description

Removed `setEnabled` and `isEnabled`. Also updated documentation for the new getter and setter.

```dart
// Before:
contact.setEnabled(true);
contact.isEnabled(); // true

// After:
contact.isEnabled = true;
contact.isEnabled; // true
```

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [X] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org