### PR TITLE
refactor!: gravity getter and setter

### DIFF
--- a/packages/forge2d/lib/src/dynamics/world.dart
+++ b/packages/forge2d/lib/src/dynamics/world.dart
@@ -22,7 +22,27 @@ class World {
   final List<Joint> joints = <Joint>[];
 
   final Vector2 _gravity;
+
+  /// The current [World]'s [gravity].
+  ///
+  /// {@template World.gravity}
+  /// All [bodies] are affected by [gravity]; unless the [Body] has a specified
+  /// [Body.gravityOverride]. If so, [Body.gravityOverride] is used instead of
+  /// [gravity].
+  ///
+  /// See also:
+  ///
+  /// * [Body.gravityScale], to multipy [gravity] for a [Body].
+  /// * [Body.gravityOverride], to change how the world treats the gravity for
+  /// a [Body].
+  /// {@endtemplate}
   Vector2 get gravity => _gravity;
+
+  /// Changes the [World]'s gravity.
+  ///
+  /// {@macro World.gravity}
+  set gravity(Vector2 gravity) => this.gravity.setFrom(gravity);
+
   bool _allowSleep = false;
 
   DestroyListener? destroyListener;
@@ -485,11 +505,6 @@ class World {
 
   /// Gets the quality of the dynamic tree
   double getTreeQuality() => contactManager.broadPhase.getTreeQuality();
-
-  /// Change the global gravity vector.
-  void setGravity(Vector2 gravity) {
-    _gravity.setFrom(gravity);
-  }
 
   /// Is the world locked (in the middle of a time step).
   bool get isLocked => (flags & locked) == locked;

--- a/packages/forge2d/test/dynamics/world_test.dart
+++ b/packages/forge2d/test/dynamics/world_test.dart
@@ -7,6 +7,17 @@ class AnotherRevoluteJoint extends RevoluteJoint {
 }
 
 void main() {
+  group('gravity', () {
+    test('can change', () {
+      final world = World();
+
+      final newGravity = world.gravity.clone()..x += 1;
+      world.gravity = newGravity;
+
+      expect(world.gravity, equals(newGravity));
+    });
+  });
+
   group(
     'createJoint',
     () {


### PR DESCRIPTION
# Description

Removed `setGravity` and `getGravity`.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [X] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org