### PR TITLE
feat!: Set the RopeJoint's local anchors to null vectors by default

### DIFF
--- a/packages/forge2d/lib/src/dynamics/joints/rope_joint_def.dart
+++ b/packages/forge2d/lib/src/dynamics/joints/rope_joint_def.dart
@@ -9,9 +9,4 @@ class RopeJointDef<A extends Body, B extends Body> extends JointDef<A, B> {
   /// The maximum length of the rope. Warning: this must be larger than
   /// linearSlop or the joint will have no effect.
   double maxLength = 0.0;
-
-  RopeJointDef() : super() {
-    localAnchorA.setValues(-1.0, 0.0);
-    localAnchorB.setValues(1.0, 0.0);
-  }
 }

--- a/packages/forge2d/test/dynamics/joints/rope_joint_def_test.dart
+++ b/packages/forge2d/test/dynamics/joints/rope_joint_def_test.dart
@@ -6,5 +6,15 @@ void main() {
     test('can be instantiated', () {
       expect(RopeJointDef(), isA<RopeJointDef>());
     });
+
+    group('constructor', () {
+      test('sets localAnchorA to zero', () {
+        expect(RopeJointDef().localAnchorA, equals(Vector2.zero()));
+      });
+
+      test('sets localAnchorB to zero', () {
+        expect(RopeJointDef().localAnchorB, equals(Vector2.zero()));
+      });
+    });
   });
 }


### PR DESCRIPTION
# Description

This caused me some headache yesterday during the gamejam. The rope joint behaved weirdly and did not follow the physics and I would expect it to do. Some investigation lead me to realize that the local anchors had a non-zero default. Setting them to zero vectors gave me the result I was looking for. I think it is reasonable to remove the old default to not cause any future confusion.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org