### PR TITLE
fix: Fixed wrong particle position when creating a particle group

### DIFF
--- a/packages/forge2d/lib/src/particle/particle_system.dart
+++ b/packages/forge2d/lib/src/particle/particle_system.dart
@@ -230,7 +230,6 @@ class ParticleSystem {
           if (shape.testPoint(identity, p)) {
             p.setFrom(Transform.mulVec2(transform, p));
             final particle = seedParticle.clone();
-            p.sub(groupDef.position);
             particle.position.setFrom(p);
             p.scaleOrthogonalInto(
               groupDef.angularVelocity,


### PR DESCRIPTION
# Description

Fixes an issue where particles created in `ParticleSystem.createParticleGroup()` were centred around `(0,0)` rather than the position stipulated in the group definition. This bug is also present in the JBox2D library.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

This should not be a breaking change as it implements expected behaviour.

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes https://github.com/flame-engine/forge2d/issues/68