### PR TITLE
docs: Improve capitalization and wording on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a title="Pub" href="https://pub.dartlang.org/packages/forge2d" ><img src="https://img.shields.io/pub/v/forge2d.svg?style=popout" /></a> <img src="https://github.com/flame-engine/forge2d/workflows/Test/badge.svg?branch=master&event=push" alt="Test" /> <a title="Discord" href="https://discord.gg/pxrBmy4" ><img src="https://img.shields.io/discord/509714518008528896.svg" /></a>
 </p>
 
-The Box2D physics engine is a fairly famous open source physics engine and this is our dart port of
+The Box2D physics engine is a fairly famous open source physics engine and this is our Dart port of
 it.
 
 You can use it independently in Dart or in your [Flame](https://github.com/flame-engine/flame)
@@ -34,9 +34,9 @@ It was then ported to Java (jbox2d) by [Daniel Murphy](https://github.com/dmurph
 Then from that Java port it was ported to Dart by [Dominic Hamon](https://github.com/dominichamon)
 and [Kevin Moore](https://github.com/kevmoo).
 
-A few years after that [Lukas Klingsbo](https://github.com/spydon) refactored the code to follow the
-dart standard more, since it still had a lot of reminiscence from C++.
-After this refactor we renamed it to Forge2D since the upstream wasn't maintained to take in our
+A few years after that [Lukas Klingsbo](https://github.com/spydon) refactored the code to better follow the
+Dart standard, since it still had a lot of reminiscence from C++.
+After this refactor, we renamed it to Forge2D, as the upstream wasn't maintained to take in our
 PRs.
 
 There has also been countless other contributors which we are very thankful to!


### PR DESCRIPTION
# Description

This:

 * capitalizes Dart when referring to the Dart language on the README (it was half-and-half before)
 * improves the wording a bit on a couple sentences

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org