### PR TITLE
docs: Update old link to flame_forge2d

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Box2D physics engine is a fairly famous open source physics engine and this 
 it.
 
 You can use it independently in Dart or in your [Flame](https://github.com/flame-engine/flame)
-project with the help of [flame_forge2d](https://github.com/flame-engine/flame_forge2d).
+project with the help of [flame_forge2d](https://github.com/flame-engine/flame/tree/main/packages/flame_forge2d).
 
 Some documentation of how to use it together with flame can be found
 [here](https://flame-engine.org/docs/#/forge2d).


### PR DESCRIPTION
# Description
Just updates an old flame_forge2d link to point at the monorepo instead.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Related Issues

Closes #79 

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org