### PR TITLE
feat: Add setLength() to DistanceJoint

### DIFF
--- a/packages/forge2d/lib/src/dynamics/joints/distance_joint.dart
+++ b/packages/forge2d/lib/src/dynamics/joints/distance_joint.dart
@@ -15,6 +15,10 @@ class DistanceJoint extends Joint {
   double _impulse = 0.0;
   double _length = 0.0;
 
+  set length(double value) {
+    _length = value;
+  }
+
   // Solver temp
   int _indexA = 0;
   int _indexB = 0;

--- a/packages/forge2d/lib/src/dynamics/joints/distance_joint.dart
+++ b/packages/forge2d/lib/src/dynamics/joints/distance_joint.dart
@@ -19,6 +19,8 @@ class DistanceJoint extends Joint {
     _length = value;
   }
 
+  double get length => _length;
+
   // Solver temp
   int _indexA = 0;
   int _indexB = 0;


### PR DESCRIPTION
# Description

This PR adds a missing API to `DistanceJoint`:

* A new method `setLength(double newLength)` to dynamically update the joint’s target length during simulation.
* A getter `length` to expose the current target length.

## Checklist

- [ ] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues