### PR TITLE
fix: Create and destroy joints after world has been locked

### DIFF
--- a/packages/forge2d/lib/src/dynamics/world.dart
+++ b/packages/forge2d/lib/src/dynamics/world.dart
@@ -25,10 +25,10 @@ class World {
   late ContactManager contactManager;
   final List<Body> bodies = <Body>[];
   final List<Joint> joints = <Joint>[];
-  final List<Body> bodiesToCreate = <Body>[];
-  final List<Body> bodiesToDestroy = <Body>[];
-  final List<Joint> jointsToCreate = <Joint>[];
-  final List<Joint> jointsToDestroy = <Joint>[];
+  final List<Body> _bodiesToCreate = <Body>[];
+  final List<Body> _bodiesToDestroy = <Body>[];
+  final List<Joint> _jointsToCreate = <Joint>[];
+  final List<Joint> _jointsToDestroy = <Joint>[];
 
   final Vector2 _gravity;
 
@@ -139,7 +139,7 @@ class World {
   Body createBody(BodyDef def) {
     final body = Body(def, this);
     if (isLocked) {
-      bodiesToCreate.add(body);
+      _bodiesToCreate.add(body);
       return body;
     }
     bodies.add(body);
@@ -153,7 +153,7 @@ class World {
   /// Warning: This function is locked during callbacks.
   void destroyBody(Body body) {
     if (isLocked) {
-      bodiesToDestroy.add(body);
+      _bodiesToDestroy.add(body);
       return;
     }
 
@@ -184,7 +184,7 @@ class World {
   /// Adding a joint doesn't wake up the bodies.
   void createJoint(Joint joint) {
     if (isLocked) {
-      jointsToCreate.add(joint);
+      _jointsToCreate.add(joint);
       return;
     }
     joints.add(joint);
@@ -209,7 +209,7 @@ class World {
   /// Destroys a joint. This may cause the connected bodies to begin colliding.
   void destroyJoint(Joint joint) {
     if (isLocked) {
-      jointsToDestroy.add(joint);
+      _jointsToDestroy.add(joint);
       return;
     }
 
@@ -308,15 +308,25 @@ class World {
 
     flags &= ~locked;
 
-    for (final body in bodiesToCreate) {
+    for (final body in _bodiesToCreate) {
       bodies.add(body);
     }
-    bodiesToCreate.clear();
+    _bodiesToCreate.clear();
 
-    for (final body in bodiesToDestroy) {
+    for (final body in _bodiesToDestroy) {
       destroyBody(body);
     }
-    bodiesToDestroy.clear();
+    _bodiesToDestroy.clear();
+
+    for (final joint in _jointsToCreate) {
+      createJoint(joint);
+    }
+    _jointsToCreate.clear();
+
+    for (final joint in _jointsToDestroy) {
+      destroyJoint(joint);
+    }
+    _jointsToDestroy.clear();
 
     _profile.step.record(_stepTimer.getMilliseconds());
   }

--- a/packages/forge2d/test/dynamics/body_test.dart
+++ b/packages/forge2d/test/dynamics/body_test.dart
@@ -83,5 +83,34 @@ void main() {
         expect(bodyInitialPosition.y, isNot(equals(body.position.y)));
       });
     });
+
+    test('creation and destruction of body while world is locked', () {
+      final world = World(Vector2(0.0, -10.0));
+      final bodyDef = BodyDef();
+
+      world.flags = World.locked;
+
+      // Attempt to create a body while the world is locked
+      final body = world.createBody(bodyDef);
+      expect(world.bodies.contains(body), isFalse);
+
+      world.flags = 0;
+      world.stepDt(1 / 60);
+
+      // Verify the body is created after unlocking the world
+      expect(world.bodies.contains(body), isTrue);
+
+      world.flags = World.locked;
+
+      // Attempt to destroy the body while the world is locked
+      world.destroyBody(body);
+      expect(world.bodies.contains(body), isTrue);
+
+      world.flags = 0;
+      world.stepDt(1 / 60);
+
+      // Verify the body is destroyed after unlocking the world
+      expect(world.bodies.contains(body), isFalse);
+    });
   });
 }

--- a/packages/forge2d/test/dynamics/joints/joint_test.dart
+++ b/packages/forge2d/test/dynamics/joints/joint_test.dart
@@ -39,5 +39,52 @@ void main() {
       expect(body1.joints.length, 0);
       expect(body2.joints.length, 0);
     });
+
+    test('destruction of body with joint while world is locked', () {
+      final world = World(Vector2(0.0, -10.0));
+      final bodyDef = BodyDef();
+      final body1 = world.createBody(bodyDef);
+      final body2 = world.createBody(bodyDef..position = Vector2.all(2));
+      final shape = CircleShape(radius: 1.2, position: Vector2.all(10));
+      final fixtureDef = FixtureDef(
+        shape,
+        density: 50.0,
+        friction: 0.1,
+        restitution: 0.9,
+      );
+
+      body1.createFixture(fixtureDef);
+      body2.createFixture(fixtureDef);
+
+      world.flags = World.locked;
+
+      final revoluteJointDef = RevoluteJointDef()
+        ..initialize(body1, body2, body1.position);
+      final revoluteJoint = RevoluteJoint(revoluteJointDef);
+      world.createJoint(revoluteJoint);
+
+      expect(body1.joints.length, 0);
+      expect(body2.joints.length, 0);
+
+      world.flags = 0;
+      world.stepDt(1 / 60);
+
+      expect(body1.joints.length, 1);
+      expect(body2.joints.length, 1);
+
+      world.flags = World.locked;
+
+      // Attempt to destroy the body while the world is locked
+      world.destroyBody(body1);
+      expect(body1.joints.length, 1);
+      expect(body2.joints.length, 1);
+
+      // Step the world again to process the destruction
+      world.flags = 0;
+      world.stepDt(1 / 60);
+
+      expect(body1.joints.length, 0);
+      expect(body2.joints.length, 0);
+    });
   });
 }


### PR DESCRIPTION
# Description

This fixes so that the queued up joints are actually created and destroyed when the world is stepped.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org