### PR TITLE
chore: Migrate to Melos 8

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,22 +12,21 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-      - uses: bluefireteam/melos-action@main
+      - uses: bluefireteam/melos-action@v3
       - run: melos run format-check
 
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
+      - uses: bluefireteam/melos-action@v3
+      - name: "Analyze with latest stable"
+        uses: invertase/github-action-dart-analyzer@v3
         with:
-          channel: 'stable'
-      - uses: bluefireteam/melos-action@main
-      - run: melos run analyze
+          fatal-infos: true
   # END LINTING STAGE
 
   # BEGIN TESTING STAGE
@@ -35,10 +34,8 @@ jobs:
     needs: [format, analyze]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-      - uses: bluefireteam/melos-action@main
-      - run: melos run test
+      - uses: bluefireteam/melos-action@v3
+      - run: melos test
   # END TESTING STAGE

--- a/packages/benchmark/pubspec.yaml
+++ b/packages/benchmark/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.0+1
 publish_to: 'none'
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 dependencies:
   build_runner: ^2.4.5

--- a/packages/forge2d/example/pubspec.yaml
+++ b/packages/forge2d/example/pubspec.yaml
@@ -6,7 +6,7 @@ resolution: workspace
 publish_to: 'none'
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 dependencies:
   forge2d: ^0.14.2+1

--- a/packages/forge2d/pubspec.yaml
+++ b/packages/forge2d/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flame-engine/forge2d
 resolution: workspace
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 dependencies:
   meta: ^1.16.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,10 +6,10 @@ workspace:
   - packages/forge2d/example
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 dev_dependencies:
-  melos: ^7.0.0-dev.9
+  melos: ^8.1.0
 
 melos:
   command:
@@ -23,60 +23,54 @@ melos:
 
     bootstrap:
       environment:
-        sdk: ">=3.8.0 <4.0.0"
+        sdk: ">=3.9.0 <4.0.0"
+      dependencies:
+        meta: ^1.16.0
+        vector_math: ^2.1.4
+        web: ^1.1.1
+      dev_dependencies:
+        dartdoc: ^8.3.4
+        flame_lint: ^1.4.1
+        mocktail: ^1.0.4
+        test: ^1.26.3
 
   scripts:
     lint:all:
-      run: melos run analyze && melos run format
+      steps:
+        - melos analyze --fatal-infos
+        - format
       description: Run all static analysis checks.
-
-    analyze:
-      run: |
-        melos exec -c 1 -- \
-          dart analyze --fatal-infos
-      description: Run `dart analyze` for all packages.
-
-    format:
-      run: melos exec dart format . --fix
-      description: Run `dart format` for all packages.
 
     format-check:
       run: melos exec dart format . --set-exit-if-changed
       description: Run `dart format` checks for all packages.
 
     dartdoc:
-      run: melos exec dart pub run dartdoc
+      exec: dart pub run dartdoc
       description: Run dartdoc checks for all packages.
 
-    test:select:
-      run: melos exec -c 1 -- dart test
-      packageFilters:
-        dirExists: test
-      description: Run `dart test` for selected packages.
-
-    test:
-      run: melos run test:select --no-select
-      description: Run all tests in this project.
-
     coverage:
-      run: |
-        melos exec -- dart test --coverage &&
-        melos exec -- genhtml coverage/lcov.info --output-directory=coverage/
+      steps:
+        - melos exec -- dart test --coverage
+        - melos exec -- genhtml coverage/lcov.info --output-directory=coverage/
       packageFilters:
         dirExists: test
       description: Generate coverage for the selected package.
 
     benchmark:
-      run: melos exec -- dart web/bench2d.dart
+      exec:
+        command: dart web/bench2d.dart
       packageFilters:
         scope: forge2d_benchmark
 
     benchmark_serve:
-      run: melos exec -- dart pub global run webdev serve --release
+      exec:
+        command: dart pub global run webdev serve --release
       packageFilters:
         scope: forge2d_benchmark
 
     example:
-      run: melos exec -- dart pub global run webdev serve --release
+      exec:
+        command: dart pub global run webdev serve --release
       packageFilters:
         scope: forge2d_examples


### PR DESCRIPTION
## Description

Sets up Melos in the same way as it is set up in the Flame repository, migrating over the [breaking changes](https://melos.invertase.dev/guides/migrations) from Melos 7 to 8.

- Bump `melos` to `^8.1.0` and the Dart SDK constraint to `>=3.9.0` (root, bootstrap config and all packages), which Melos requires for reliable pub workspace support.
- Sync common dependencies from the root via `bootstrap.dependencies` and `bootstrap.dev_dependencies`, like Flame does.
- Drop the custom `analyze`, `format`, `test:select` and `test` scripts, since `melos analyze`, `melos format` and `melos test` are built-in commands now.
- Migrate the remaining exec based scripts (`dartdoc`, `benchmark`, `benchmark_serve`, `example`) to the Melos 8 `exec:` form, since `run:` combined with `exec:` options is no longer supported.
- Use `steps:` for `lint:all` and `coverage` instead of `&&` chaining.
- Update the CI workflow to `melos-action@v3` and `checkout@v4`, use the built-in `melos test`, and analyze with `invertase/github-action-dart-analyzer` (with `fatal-infos`), which is what Flame uses.

The release workflows already used `melos-action@v3` and needed no changes.

## Testing instructions

With Melos 8 activated (`dart pub global activate melos`):

```
melos bootstrap
melos analyze --fatal-infos
melos test
melos run format-check
melos run lint:all
```

All of the above were verified locally with Melos 8.2.2, and the 88 tests in `forge2d` pass.